### PR TITLE
Fix invalid buffer size reported on iOS

### DIFF
--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -690,15 +690,18 @@ private:
         AudioUnitSetProperty (audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input,  0, &format, sizeof (format));
         AudioUnitSetProperty (audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &format, sizeof (format));
 
-        UInt32 framesPerSlice;
-        UInt32 dataSize = sizeof (framesPerSlice);
+        // The below code is not correct, and has been removed by us (Yousician) due to the Juce guys being to slow in fixing it,
+        // see https://forum.juce.com/t/block-size-on-ios-8/17280 for details.
+        
+        //UInt32 framesPerSlice;
+        //UInt32 dataSize = sizeof (framesPerSlice);
 
-        if (AudioUnitGetProperty (audioUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &framesPerSlice, &dataSize) == noErr
-               && dataSize == sizeof (framesPerSlice) && framesPerSlice != actualBufferSize)
-        {
-            actualBufferSize = framesPerSlice;
-            prepareFloatBuffers (actualBufferSize);
-        }
+        //if (AudioUnitGetProperty (audioUnit, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0, &framesPerSlice, &dataSize) == noErr
+        //       && dataSize == sizeof (framesPerSlice) && framesPerSlice != actualBufferSize)
+        //{
+        //    actualBufferSize = framesPerSlice;
+        //    prepareFloatBuffers (actualBufferSize);
+        //}
 
         AudioUnitInitialize (audioUnit);
         return true;


### PR DESCRIPTION
This is a regression in JUCE.

Leaving the code in there for easier merge conflict resolution when they (hopefully) fix it. We want a conflict here, so I commented it out line-by-line.

See https://forum.juce.com/t/block-size-on-ios-8/17280 for details.
