### PR TITLE
Add MIDI detection on Windows

### DIFF
--- a/modules/juce_audio_devices/midi_io/juce_MidiSetup.h
+++ b/modules/juce_audio_devices/midi_io/juce_MidiSetup.h
@@ -6,7 +6,7 @@
 
 //==============================================================================
 /**
- 
+
  */
 class JUCE_API  MidiSetupListener
 {
@@ -21,14 +21,14 @@ public:
 class JUCE_API  MidiSetup
 {
 public:
-    
-    #if JUCE_MAC || JUCE_IOS || DOXYGEN
-    /** Listen to setup changes (Only available on iOS and OS X).
-     
+
+    #if JUCE_MAC || JUCE_IOS || JUCE_WINDOWS || DOXYGEN
+    /** Listen to setup changes (Only available on iOS, OS X and Windows).
+
      */
     static void addListener (MidiSetupListener * const listener);
     static void removeListener (MidiSetupListener * const listener);
-    
+
     #endif
 };
 


### PR DESCRIPTION
JUCE conveniently provides and internal DeviceChangeDetector class which instantiates a dummy window and uses its event callback to detect changes in the hardware configuration. I have specialised it to handle changes in the MIDI configuration and to register/unregister listeners.

I am doing no thread synchronisation here; the client code must take care of instantiating the dummy windows in the same thread as the JUCE message loop (as we are indeed doing in the Yousician code).

The callbacks are also run in the message thread by JUCE.
