### PR TITLE
Change default android buffer size to be twice the native buffer size on non-pro-audio devices

### DIFF
--- a/modules/juce_audio_devices/native/juce_android_OpenSL.cpp
+++ b/modules/juce_audio_devices/native/juce_android_OpenSL.cpp
@@ -206,8 +206,7 @@ public:
         // Only on a Pro-Audio device will we set the lowest possible buffer size
         // by default. We need to be more conservative on other devices
         // as they may be low-latency, but still have a crappy CPU.
-        //return (isProAudioDevice() ? 1 : 6) * defaultBufferSizeIsMultipleOfNative * getNativeBufferSize();
-        return getNativeBufferSize();
+        return (isProAudioDevice() ? 1 : 2) * defaultBufferSizeIsMultipleOfNative * getNativeBufferSize();
     }
 
     double getCurrentSampleRate() override


### PR DESCRIPTION
This seems to fix some issues on certain Android devices, where buffer underruns cause changes in latency.
