### PR TITLE
MIDI detection on Android

### DIFF
--- a/modules/juce_audio_devices/midi_io/juce_MidiSetup.h
+++ b/modules/juce_audio_devices/midi_io/juce_MidiSetup.h
@@ -21,15 +21,8 @@ public:
 class JUCE_API  MidiSetup
 {
 public:
-
-    #if JUCE_MAC || JUCE_IOS || JUCE_WINDOWS || DOXYGEN
-    /** Listen to setup changes (Only available on iOS, OS X and Windows).
-
-     */
     static void addListener (MidiSetupListener * const listener);
     static void removeListener (MidiSetupListener * const listener);
-
-    #endif
 };
 
 

--- a/modules/juce_audio_devices/midi_io/juce_MidiSetup.h
+++ b/modules/juce_audio_devices/midi_io/juce_MidiSetup.h
@@ -21,6 +21,7 @@ public:
 class JUCE_API  MidiSetup
 {
 public:
+    static bool supportsMidi ();
     static void addListener (MidiSetupListener * const listener);
     static void removeListener (MidiSetupListener * const listener);
 };

--- a/modules/juce_audio_devices/native/juce_android_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Midi.cpp
@@ -401,6 +401,11 @@ JUCE_JNI_CALLBACK(JUCE_ANDROID_ACTIVITY_CLASSNAME, midiDevicesChanged, void, (JN
     getMidiChangeDetector().emitMidiDevicesChanged();
 }
 
+bool MidiSetup::supportsMidi()
+{
+    return android.activity.callBooleanMethod(JuceAppActivity.supportsMidiAndBluetooth);
+}
+
 void MidiSetup::addListener(MidiSetupListener* const listener)
 {
     getMidiChangeDetector().addListener(listener);

--- a/modules/juce_audio_devices/native/juce_android_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Midi.cpp
@@ -29,7 +29,7 @@
  METHOD (openMidiOutputPortWithJuceIndex, "openMidiOutputPortWithJuceIndex", "(I)L" JUCE_ANDROID_ACTIVITY_CLASSPATH "$JuceMidiPort;") \
  METHOD (getInputPortNameForJuceIndex, "getInputPortNameForJuceIndex", "(I)Ljava/lang/String;") \
  METHOD (getOutputPortNameForJuceIndex, "getOutputPortNameForJuceIndex", "(I)Ljava/lang/String;")
- DECLARE_JNI_CLASS (MidiDeviceManager, JUCE_ANDROID_ACTIVITY_CLASSPATH "$MidiDeviceManager")
+ DECLARE_JNI_CLASS (MidiDeviceManager, JUCE_ANDROID_ACTIVITY_CLASSPATH "$MidiDeviceManagerInterface")
 #undef JNI_CLASS_MEMBERS
 
 #define JNI_CLASS_MEMBERS(METHOD, STATICMETHOD, FIELD, STATICFIELD) \
@@ -358,4 +358,55 @@ void MidiInput::stop()
 MidiInput::~MidiInput()
 {
     delete reinterpret_cast<AndroidMidiInput*> (internal);
+}
+
+class MidiChangeDetector
+{
+public:
+    void addListener(MidiSetupListener* const listener)
+    {
+        listeners.addIfNotAlreadyThere(listener);
+    }
+
+    void removeListener(MidiSetupListener* const listener)
+    {
+        listeners.removeFirstMatchingValue(listener);
+    }
+
+    void emitMidiDevicesChanged()
+    {
+        for (auto& listener : listeners)
+        {
+            listener->midiDevicesChanged();
+        }
+    }
+
+private:
+    Array<MidiSetupListener*> listeners;
+};
+
+namespace {
+
+MidiChangeDetector& getMidiChangeDetector()
+{
+    static MidiChangeDetector detector;
+    return detector;
+}
+
+}
+
+JUCE_JNI_CALLBACK(JUCE_ANDROID_ACTIVITY_CLASSNAME, midiDevicesChanged, void, (JNIEnv* env, jobject))
+{
+    setEnv(env);
+    getMidiChangeDetector().emitMidiDevicesChanged();
+}
+
+void MidiSetup::addListener(MidiSetupListener* const listener)
+{
+    getMidiChangeDetector().addListener(listener);
+}
+
+void MidiSetup::removeListener(MidiSetupListener* const listener)
+{
+    getMidiChangeDetector().removeListener(listener);
 }

--- a/modules/juce_audio_devices/native/juce_mac_CoreMidi.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreMidi.cpp
@@ -569,6 +569,11 @@ void MidiInput::stop()
 
 //==============================================================================
 
+bool MidiSetup::supportsMidi()
+{
+    return true;
+}
+
 void MidiSetup::addListener (MidiSetupListener * const listener)
 {
     auto & state = CoreMidiHelpers::getGlobalMidiSetupState();

--- a/modules/juce_audio_devices/native/juce_win32_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_Midi.cpp
@@ -537,6 +537,11 @@ void MidiOutput::sendMessageNow (const MidiMessage& message)
     }
 }
 
+bool MidiSupport::supportsMidi()
+{
+    return true;
+}
+
 void MidiSetup::addListener(MidiSetupListener* const l)
 {
     getMidiChangeDetector().addListener(l);

--- a/modules/juce_audio_devices/native/juce_win32_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_Midi.cpp
@@ -537,7 +537,7 @@ void MidiOutput::sendMessageNow (const MidiMessage& message)
     }
 }
 
-bool MidiSupport::supportsMidi()
+bool MidiSetup::supportsMidi()
 {
     return true;
 }

--- a/modules/juce_core/native/java/AndroidMidi.java
+++ b/modules/juce_core/native/java/AndroidMidi.java
@@ -830,6 +830,8 @@
             // Do not add bluetooth devices as they are already added by the native bluetooth dialog
             if (info.getType() != MidiDeviceInfo.TYPE_BLUETOOTH)
                 physicalMidiDevices.add (device);
+
+            midiDevicesChanged();
         }
 
         @Override
@@ -840,6 +842,7 @@
                 if (physicalMidiDevices.get(i).info.getId() == info.getId())
                 {
                     physicalMidiDevices.remove (i);
+                    midiDevicesChanged();
                     return;
                 }
             }

--- a/modules/juce_core/native/java/AndroidMidi.java
+++ b/modules/juce_core/native/java/AndroidMidi.java
@@ -1,6 +1,12 @@
     public boolean supportsMidiAndBluetooth()
     {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+        // Android introduced MIDI support in the API with version 23. In addition, we have
+        // observer empirically that only devices with audio.pro and audio.low_latency can
+        // detect and interact with MIDI devices.
+
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+            && hasSystemFeature("android.hardware.audio.pro")
+            && hasSystemFeature("android.hardware.audio.low_latency");
     }
 
     //==============================================================================

--- a/modules/juce_core/native/java/JuceAppActivity.java
+++ b/modules/juce_core/native/java/JuceAppActivity.java
@@ -24,6 +24,8 @@
 
 package com.juce;
 
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
@@ -33,6 +35,7 @@ import android.content.res.Configuration;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
 import android.os.Handler;
@@ -312,7 +315,7 @@ public class JuceAppActivity   extends Activity
 
     //==============================================================================
     private ViewHolder viewHolder;
-    private MidiDeviceManager midiDeviceManager = null;
+    private MidiDeviceManagerInterface midiDeviceManager = null;
     private BluetoothManager bluetoothManager = null;
     private boolean isScreenSaverEnabled;
     private java.util.Timer keepAliveTimer;

--- a/modules/juce_core/native/juce_android_JNIHelpers.h
+++ b/modules/juce_core/native/juce_android_JNIHelpers.h
@@ -287,7 +287,7 @@ extern AndroidSystem android;
  METHOD (getTypeFaceFromByteArray,"getTypeFaceFromByteArray","([B)Landroid/graphics/Typeface;") \
  METHOD (setScreenSaver,          "setScreenSaver",       "(Z)V") \
  METHOD (getScreenSaver,          "getScreenSaver",       "()Z") \
- METHOD (getAndroidMidiDeviceManager, "getAndroidMidiDeviceManager", "()L" JUCE_ANDROID_ACTIVITY_CLASSPATH "$MidiDeviceManager;") \
+ METHOD (getAndroidMidiDeviceManager, "getAndroidMidiDeviceManager", "()L" JUCE_ANDROID_ACTIVITY_CLASSPATH "$MidiDeviceManagerInterface;") \
  METHOD (getAndroidBluetoothManager, "getAndroidBluetoothManager", "()L" JUCE_ANDROID_ACTIVITY_CLASSPATH "$BluetoothManager;") \
  METHOD (getAndroidSDKVersion,    "getAndroidSDKVersion", "()I") \
  METHOD (audioManagerGetProperty, "audioManagerGetProperty", "(Ljava/lang/String;)Ljava/lang/String;") \

--- a/modules/juce_core/native/juce_android_JNIHelpers.h
+++ b/modules/juce_core/native/juce_android_JNIHelpers.h
@@ -287,6 +287,7 @@ extern AndroidSystem android;
  METHOD (getTypeFaceFromByteArray,"getTypeFaceFromByteArray","([B)Landroid/graphics/Typeface;") \
  METHOD (setScreenSaver,          "setScreenSaver",       "(Z)V") \
  METHOD (getScreenSaver,          "getScreenSaver",       "()Z") \
+ METHOD (supportsMidiAndBluetooth, "supportsMidiAndBluetooth", "()Z") \
  METHOD (getAndroidMidiDeviceManager, "getAndroidMidiDeviceManager", "()L" JUCE_ANDROID_ACTIVITY_CLASSPATH "$MidiDeviceManagerInterface;") \
  METHOD (getAndroidBluetoothManager, "getAndroidBluetoothManager", "()L" JUCE_ANDROID_ACTIVITY_CLASSPATH "$BluetoothManager;") \
  METHOD (getAndroidSDKVersion,    "getAndroidSDKVersion", "()I") \


### PR DESCRIPTION
- JUCE can now detect if an Android device supports MIDI and thus detect changes in the MIDI configuration. At the moment I'm only checking that the API supports midi (>= Marshmallow). I'm not sure if we should also enforce additional flags (low_latency, pro audio)
- Added an API to test for MIDI support: TRUE for OSX, iOS, Windows and Android >= Marshmallow, FALSE otherwise (again, we need to decide if we want to test additional features)
