### PR TITLE
Reverse increase in buffer size on high-latency devices

### DIFF
--- a/modules/juce_audio_devices/native/juce_android_OpenSL.cpp
+++ b/modules/juce_audio_devices/native/juce_android_OpenSL.cpp
@@ -206,7 +206,8 @@ public:
         // Only on a Pro-Audio device will we set the lowest possible buffer size
         // by default. We need to be more conservative on other devices
         // as they may be low-latency, but still have a crappy CPU.
-        return (isProAudioDevice() ? 1 : 2) * defaultBufferSizeIsMultipleOfNative * getNativeBufferSize();
+        //return (isProAudioDevice() ? 1 : 6) * defaultBufferSizeIsMultipleOfNative * getNativeBufferSize();
+        return getNativeBufferSize();
     }
 
     double getCurrentSampleRate() override


### PR DESCRIPTION
Rollback increase in audio buffer size for high-latency Android devices.
