### PR TITLE
Add audio input support for device with 16kHz sampling rate

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -290,7 +290,7 @@ public:
 
             if (OK (AudioObjectGetPropertyData (deviceID, &pa, 0, nullptr, &size, ranges)))
             {
-                static const double possibleRates[] = { 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0, 384000.0 };
+                static const double possibleRates[] = { 16000.0, 44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0, 384000.0 };
 
                 for (int i = 0; i < numElementsInArray (possibleRates); ++i)
                 {

--- a/modules/juce_audio_devices/native/juce_win32_ASIO.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_ASIO.cpp
@@ -365,7 +365,7 @@ public:
     void updateSampleRates()
     {
         // find a list of sample rates..
-        const int possibleSampleRates[] = { 44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000 };
+        const int possibleSampleRates[] = { 16000, 44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000 };
         Array<double> newRates;
 
         if (asioObject != nullptr)

--- a/modules/juce_audio_devices/native/juce_win32_DirectSound.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_DirectSound.cpp
@@ -782,7 +782,7 @@ public:
 
     Array<double> getAvailableSampleRates() override
     {
-        static const double rates[] = { 44100.0, 48000.0, 88200.0, 96000.0 };
+        static const double rates[] = { 16000.0, 44100.0, 48000.0, 88200.0, 96000.0 };
         return Array<double> (rates, numElementsInArray (rates));
     }
 

--- a/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp
@@ -400,7 +400,7 @@ public:
             // Got a format that is supported by the device so we can ask what sample rates are supported (in whatever format)
         }
 
-        static const int ratesToTest[] = { 44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000 };
+        static const int ratesToTest[] = { 16000, 44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000 };
 
         for (int i = 0; i < numElementsInArray (ratesToTest); ++i)
         {


### PR DESCRIPTION
The device in question (Parrot Zik 3) has a line-in with a sampling rate of 16kHz. As you can see from the diffs, this was not among the input sampling rates accepted by JUCE. I have just added 16kHz to the list.

I could only test this on some platforms:
- OSX - CoreAudio: support added and tested
- iOS - CoreAudio: could not test, the device was not recognized as an input
- Windows
  - Windows Audio: support added and tested
  - ASIO: support added but not tested (no available drivers and could not find an interface delivering 16kHz), but the logic looks similar to Windows Audio
  - DirectSound: same as ASIO
- Android: <s>support not added</s> 16kHz already supported, the device was not recognised as an input
