### PR TITLE
Roll back audio unit initialisation merge on iOS

### DIFF
--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -690,22 +690,24 @@ private:
         AudioUnitSetProperty (audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input,  0, &format, sizeof (format));
         AudioUnitSetProperty (audioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &format, sizeof (format));
 
-        UInt32 framesPerSlice;
-        UInt32 dataSize = sizeof (framesPerSlice);
+//        The below code is not correct, and has been removed by us (Yousician) due to the Juce guys being to slow in fixing it,
+//        see https://forum.juce.com/t/block-size-on-ios-8/17280 for details.
+//        UInt32 framesPerSlice;
+//        UInt32 dataSize = sizeof (framesPerSlice);
 
         AudioUnitInitialize (audioUnit);
 
-        AudioUnitSetProperty (audioUnit, kAudioUnitProperty_MaximumFramesPerSlice,
-                              kAudioUnitScope_Global, 0, &actualBufferSize, sizeof (actualBufferSize));
+//        AudioUnitSetProperty (audioUnit, kAudioUnitProperty_MaximumFramesPerSlice,
+//                              kAudioUnitScope_Global, 0, &actualBufferSize, sizeof (actualBufferSize));
 
 
-        if (AudioUnitGetProperty (audioUnit, kAudioUnitProperty_MaximumFramesPerSlice,
-                                  kAudioUnitScope_Global, 0, &framesPerSlice, &dataSize) == noErr
-            && dataSize == sizeof (framesPerSlice) && static_cast<int> (framesPerSlice) != actualBufferSize)
-        {
-            actualBufferSize = static_cast<int> (framesPerSlice);
-            prepareFloatBuffers (actualBufferSize);
-        }
+//        if (AudioUnitGetProperty (audioUnit, kAudioUnitProperty_MaximumFramesPerSlice,
+//                                  kAudioUnitScope_Global, 0, &framesPerSlice, &dataSize) == noErr
+//            && dataSize == sizeof (framesPerSlice) && static_cast<int> (framesPerSlice) != actualBufferSize)
+//        {
+//            actualBufferSize = static_cast<int> (framesPerSlice);
+//            prepareFloatBuffers (actualBufferSize);
+//        }
 
         return true;
     }


### PR DESCRIPTION
Rolled back the merge of the audio unit buffer size initialisation. As far as I could see, the code from JUCE works on some devices, but fails on others (iPhone7, iPad Pro). I debugged it a little bit, and sometimes the audio was not working even when the audio thread was receiving the right number of samples.

I left the thread synchronisation logic in, though, as I saw no problem with it during testing.