### PR TITLE
[YS-3228] Integrate USB-MIDI-Driver library

### DIFF
--- a/modules/juce_audio_devices/native/juce_android_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Midi.cpp
@@ -403,7 +403,7 @@ MidiChangeDetector& getMidiChangeDetector()
 
 }
 
-JUCE_JNI_CALLBACK(JUCE_ANDROID_ACTIVITY_CLASSNAME, midiDevicesChanged, void, (JNIEnv* env, jobject))
+JUCE_JNI_CALLBACK(JUCE_ANDROID_ACTIVITY_CLASSNAME, midiDevicesChanged, void, (JNIEnv* env, jclass))
 {
     setEnv(env);
     getMidiChangeDetector().emitMidiDevicesChanged();

--- a/modules/juce_audio_devices/native/juce_android_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Midi.cpp
@@ -149,6 +149,14 @@ JUCE_JNI_CALLBACK (JUCE_JOIN_MACRO (JUCE_ANDROID_ACTIVITY_CLASSNAME, _00024JuceM
     reinterpret_cast<AndroidMidiInput*> (host)->receive (byteArray, offset, count, timestamp);
 }
 
+JUCE_JNI_CALLBACK(com_yousician_yousiciandsp_MidiUsbToJuce_00024InputPort, handleReceive,
+    void, (JNIEnv* env, jobject device, jlong host, jbyteArray byteArray,
+    jint offset, jint count, jlong timestamp))
+{
+    setEnv(env);
+    reinterpret_cast<AndroidMidiInput*>(host)->receive(byteArray, offset, count, timestamp);
+}
+
 //==============================================================================
 class AndroidMidiDeviceManager
 {

--- a/modules/juce_audio_devices/native/juce_android_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Midi.cpp
@@ -403,7 +403,7 @@ JUCE_JNI_CALLBACK(JUCE_ANDROID_ACTIVITY_CLASSNAME, midiDevicesChanged, void, (JN
 
 bool MidiSetup::supportsMidi()
 {
-    return android.activity.callBooleanMethod(JuceAppActivity.supportsMidiAndBluetooth);
+    return true;
 }
 
 void MidiSetup::addListener(MidiSetupListener* const listener)

--- a/modules/juce_core/native/juce_android_JNIHelpers.h
+++ b/modules/juce_core/native/juce_android_JNIHelpers.h
@@ -287,7 +287,6 @@ extern AndroidSystem android;
  METHOD (getTypeFaceFromByteArray,"getTypeFaceFromByteArray","([B)Landroid/graphics/Typeface;") \
  METHOD (setScreenSaver,          "setScreenSaver",       "(Z)V") \
  METHOD (getScreenSaver,          "getScreenSaver",       "()Z") \
- METHOD (supportsMidiAndBluetooth, "supportsMidiAndBluetooth", "()Z") \
  METHOD (getAndroidMidiDeviceManager, "getAndroidMidiDeviceManager", "()L" JUCE_ANDROID_ACTIVITY_CLASSPATH "$MidiDeviceManagerInterface;") \
  METHOD (getAndroidBluetoothManager, "getAndroidBluetoothManager", "()L" JUCE_ANDROID_ACTIVITY_CLASSPATH "$BluetoothManager;") \
  METHOD (getAndroidSDKVersion,    "getAndroidSDKVersion", "()I") \


### PR DESCRIPTION
A few changes needed for [PR-239](https://github.com/YousicianGit/Yousician-DSP/pull/239). The method `supportsMidi()` now returns `true` on all platforms. We may want to refactor this in the future. We have for example a couple of Android phones that will just not connect to a MIDI controller, not even through USB. If I figure out a better check, I'll add it in the future.