### PR TITLE
[YS-3567] MIDI support check fails if device does not provide USB host mode

### DIFF
--- a/modules/juce_audio_devices/native/juce_android_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Midi.cpp
@@ -411,7 +411,11 @@ JUCE_JNI_CALLBACK(JUCE_ANDROID_ACTIVITY_CLASSNAME, midiDevicesChanged, void, (JN
 
 bool MidiSetup::supportsMidi()
 {
-    return true;
+    // At the very minimum, a device has to support USB host mode to be able to see a MIDI controller.
+    // If the device supports MIDI_SERVICE (requires API 23 or higher), MIDI is driven from the native
+    // Android API. If not, we fall back to a third-party USB MIDI driver.
+    const LocalRef<jstring> property(javaString("android.hardware.usb.host"));
+    return android.activity.callBooleanMethod(JuceAppActivity.hasSystemFeature, property.get());
 }
 
 void MidiSetup::addListener(MidiSetupListener* const listener)


### PR DESCRIPTION
For the time being we assume no MIDI over bluetooth, which would require additional testing anyway. If an Android device does not support USB hosting, it cannot be connected to an USB MIDI controller, so the user will see a notification in the audio settings that MIDI is not supported.