### PR TITLE
[YS-3358] Process MIDI setup changes in JUCE main thread

### DIFF
--- a/modules/juce_audio_devices/native/juce_android_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Midi.cpp
@@ -381,7 +381,7 @@ public:
         listeners.removeFirstMatchingValue(listener);
     }
 
-    void emitMidiDevicesChanged()
+    void midiDevicesChanged()
     {
         for (auto& listener : listeners)
         {
@@ -405,8 +405,16 @@ MidiChangeDetector& getMidiChangeDetector()
 
 JUCE_JNI_CALLBACK(JUCE_ANDROID_ACTIVITY_CLASSNAME, midiDevicesChanged, void, (JNIEnv* env, jclass))
 {
+    struct DevicesChangedMessage : public CallbackMessage
+    {
+        void messageCallback() override
+        {
+            getMidiChangeDetector().midiDevicesChanged();
+        }
+    };
+
     setEnv(env);
-    getMidiChangeDetector().emitMidiDevicesChanged();
+    (new DevicesChangedMessage())->post();
 }
 
 bool MidiSetup::supportsMidi()


### PR DESCRIPTION
This seems to fix the random crashes when plugging and unplugging MIDI controllers on Android. I could not find the exact cause of the crashes, as recently I've had trouble reproducing them and the stack traces from the existing crashes are inconclusive. Also, I did not see anything wrong with the code. However, the callback `midiDevicesChanged` method is called from different threads, so I suppose something could get messed up along the line.