### PR TITLE
Add locks to the MIDI device observers

### DIFF
--- a/modules/juce_audio_devices/native/juce_android_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Midi.cpp
@@ -373,16 +373,19 @@ class MidiChangeDetector
 public:
     void addListener(MidiSetupListener* const listener)
     {
+        ScopedLock lock(mutex);
         listeners.addIfNotAlreadyThere(listener);
     }
 
     void removeListener(MidiSetupListener* const listener)
     {
+        ScopedLock lock(mutex);
         listeners.removeFirstMatchingValue(listener);
     }
 
     void midiDevicesChanged()
     {
+        ScopedLock lock(mutex);
         for (auto& listener : listeners)
         {
             listener->midiDevicesChanged();
@@ -390,6 +393,7 @@ public:
     }
 
 private:
+    CriticalSection mutex;
     Array<MidiSetupListener*> listeners;
 };
 

--- a/modules/juce_audio_devices/native/juce_win32_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_Midi.cpp
@@ -29,14 +29,16 @@ public:
     MidiChangeDetector() : DeviceChangeDetector(L"MidiChangeDetector")
     {}
 
-    void addListener(MidiSetupListener* const l)
+    void addListener(MidiSetupListener* const listener)
     {
-        listeners.addIfNotAlreadyThere(l);
+        ScopedLock lock(mutex);
+        listeners.addIfNotAlreadyThere(listener);
     }
 
-    void removeListener(MidiSetupListener* const l)
+    void removeListener(MidiSetupListener* const listener)
     {
-        listeners.removeFirstMatchingValue(l);
+        ScopedLock lock(mutex);
+        listeners.removeFirstMatchingValue(listener);
     }
 
 private:
@@ -50,6 +52,7 @@ private:
         if (newDeviceNames != deviceNames)
         {
             deviceNames = newDeviceNames;
+            ScopedLock lock(mutex);
             for (auto& listener : listeners)
             {
                 listener->midiDevicesChanged();
@@ -57,6 +60,7 @@ private:
         }
     }
 
+    CriticalSection mutex;
     StringArray deviceNames;
     Array<MidiSetupListener*> listeners;
 };


### PR DESCRIPTION
Added locks to synchronise the MIDI device listeners. This is so that a listener doesn't get removed (e.g. by the Unity garbage collector) while being called. Already present for Mac/iOS. This is a bit of a temporary fix while waiting for the audio engine refactoring. After it, thread synchronisation will be moved to Yousician-Native.