### PR TITLE
Add proper latency reporting for the Android Java API

### DIFF
--- a/modules/juce_audio_devices/audio_io/juce_AudioIODevice.cpp
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODevice.cpp
@@ -32,6 +32,7 @@ AudioIODevice::~AudioIODevice() {}
 void AudioIODeviceCallback::audioDeviceError (const String&)    {}
 bool AudioIODevice::setAudioPreprocessingEnabled (bool)         { return false; }
 bool AudioIODevice::hasControlPanel() const                     { return false; }
+void AudioIODeviceCallback::audioDeviceOutputLatencyChanged (int) {}
 
 bool AudioIODevice::showControlPanel()
 {

--- a/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h
@@ -111,6 +111,10 @@ public:
         this callback.
     */
     virtual void audioDeviceError (const String& errorMessage);
+
+    /** This can be overridden to be told if the device reports a change in output latency.
+    */
+    virtual void audioDeviceOutputLatencyChanged (int latencyInSamples);
 };
 
 

--- a/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h
@@ -113,6 +113,9 @@ public:
     virtual void audioDeviceError (const String& errorMessage);
 
     /** This can be overridden to be told if the device reports a change in output latency.
+        This could be called from any thread, including the main audio processing thread.
+        Therefore, this function should return quickly, and delegate any significant amount
+        of work to other threads in the system.
     */
     virtual void audioDeviceOutputLatencyChanged (int latencyInSamples);
 };

--- a/modules/juce_core/system/juce_StandardHeader.h
+++ b/modules/juce_core/system/juce_StandardHeader.h
@@ -57,6 +57,7 @@
 #include <iostream>
 #include <functional>
 #include <algorithm>
+#include <chrono>
 
 //==============================================================================
 #include "juce_CompilerSupport.h"


### PR DESCRIPTION
This change introduces output latency calculation based on timestamps
for the Android Java API.  Because timestamps for samples are only
available after the first sample of the stream has reached the audio
output, the implementation also adds a callback function that lets the
client know about chnages in output latency.

This change is related to streaming video player audio through the
Yousician audio engine, and the need to know the actual latency there.

YS-9374