### PR TITLE
[YS-12139] Fix getDepthFromDevice method in CoreAudio driver

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -376,16 +376,46 @@ public:
 
     int getBitDepthFromDevice (AudioObjectPropertyScope scope) const
     {
-        AudioObjectPropertyAddress pa;
-        pa.mElement = kAudioObjectPropertyElementMaster;
-        pa.mSelector = kAudioStreamPropertyPhysicalFormat;
-        pa.mScope = scope;
+        auto const streamsProperty = AudioObjectPropertyAddress{
+            kAudioDevicePropertyStreams,
+            scope,
+            kAudioObjectPropertyElementMaster
+        };
 
-        AudioStreamBasicDescription asbd;
-        UInt32 size = sizeof (asbd);
+        UInt32 size = 0;
+        if (OK(AudioObjectGetPropertyDataSize(deviceID, &streamsProperty, 0, nullptr, &size)) && (size > 0))
+        {
+            std::vector<UInt32> streamIds(size / sizeof(UInt32));
 
-        if (OK (AudioObjectGetPropertyData (deviceID, &pa, 0, nullptr, &size, &asbd)))
-            return (int) asbd.mBitsPerChannel;
+            if (OK(AudioObjectGetPropertyData(
+                deviceID, &streamsProperty, 0, nullptr, &size, streamIds.data())) && (size > 0))
+            {
+                UInt32 const numStreams = size / sizeof(UInt32);
+                std::vector<int> bitDepths(numStreams);
+
+                std::transform(
+                    streamIds.begin(),
+                    streamIds.begin() + numStreams,
+                    bitDepths.begin(),
+                    [
+                        this,
+                        property = AudioObjectPropertyAddress{
+                            kAudioStreamPropertyVirtualFormat,
+                            scope,
+                            kAudioObjectPropertyElementMaster }
+                    ](auto streamId)
+                    {
+                        UInt32 size = sizeof(AudioStreamBasicDescription);
+                        AudioStreamBasicDescription descriptor;
+                        return (OK(AudioObjectGetPropertyData(streamId, &property, 0, nullptr, &size, &descriptor))
+                                && (size > 0))
+                               ? static_cast<int>(descriptor.mBitsPerChannel)
+                               : 0;
+                    });
+
+                return *std::max_element(bitDepths.begin(), bitDepths.end());
+            }
+        }
 
         return 0;
     }


### PR DESCRIPTION
There were two main issues with the original code:
*  The `kAudioStreamPropertyPhysicalFormat` belongs in the `AudioStream` class, but the code attempted to retrieve it from an instance of the `AudioDevice` class. Although this somehow worked in most cases, it is not consistent with the CoreAudio documentation, so I changed it. What I do now is retrieve the streams from the parent `AudioDevice` and take the bit depth from each one of them.
* The specific case where the code above did not work was when attempting to retrieve an input stream from an output-only device (e.g. the internal microphone) and vice-versa. This is now fixed by first retrieving the number of streams for the device in a given direction, and then retrieving the bit depth only when that number is non-zero.