### PR TITLE
[YS-12148] Resolve deadlock when stopping an audio driver and removing a device

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -39,6 +39,15 @@
  #endif
 #endif
 
+namespace
+{
+void replaceHandle(EventLoop::RaiiHandle& handle, std::function<EventLoop::RaiiHandle()> factory)
+{
+    handle = nullptr;
+    handle = factory();
+}
+}
+
 //==============================================================================
 struct SystemVol
 {
@@ -781,7 +790,8 @@ public:
     {
         if (callbacksAllowed)
         {
-            handle_ = eventLoop().dispatch([this] { timerCallback(); }, std::chrono::milliseconds(100));
+            using namespace std::chrono;
+            replaceHandle(handle_, [this] { return eventLoop().dispatch([this] { timerCallback(); }, 100ms); });
         }
     }
 

--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -1971,8 +1971,18 @@ public:
 
     void audioDeviceListChanged()
     {
-        scanForDevices();
-        callDeviceChangeListeners();
+        replaceHandle(
+            handle_,
+            [this]
+            {
+                return eventLoop().dispatch(
+                    [this]
+                    {
+                        scanForDevices();
+                        callDeviceChangeListeners();
+                    },
+                    {});
+            });
     }
 
     void triggerAsyncAudioDeviceListChange()
@@ -1986,6 +1996,7 @@ private:
     Array<AudioDeviceID> inputIds, outputIds;
 
     bool hasScanned;
+    EventLoop::RaiiHandle handle_;
 
     static int getNumChannels (AudioDeviceID deviceID, bool input)
     {


### PR DESCRIPTION
There was a deadlock in `AudioIOCombiner` that was triggered when shutting down the audio driver and removing a device at the same time. The locking threads are:
1. The event loop thread, which shuts down the audio driver.
2. The OSX thread that listens to device changes. This calls `CoreAudioIODeviceType::audioDeviceListChanges`, which in turn calls `AudioDriverInfoProvider::devicesChanged`, which then propagates to the managed side to refresh the list of attached devices.

Thread (1) tries to delete the audio device, but the `CoreAudioInternal` destructor blocks until all pending notifications related to that device have been processed. Meanwhile, thread (2), which is supposed to do that, is blocking in `AudioIOCombiner` waiting for (1).

The fix is to dispatch the hardware notification from (2) to (1), so it can be processed sequentially with the `CoreAudioInternal` destructor.

In addition, one minor code improvement, unrelated to this bug: in `CoreAudioInternal`, when dispatching device changes to the event loop, we now make sure any pre-existing dispatches are cleared.
