### PR TITLE
[YS-12886] Move replaceHandle method to YsJuce

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -39,15 +39,6 @@
  #endif
 #endif
 
-namespace
-{
-void replaceHandle(EventLoop::RaiiHandle& handle, std::function<EventLoop::RaiiHandle()> factory)
-{
-    handle = nullptr;
-    handle = factory();
-}
-}
-
 //==============================================================================
 struct SystemVol
 {

--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -811,8 +811,7 @@ public:
     {
         if (callbacksAllowed)
         {
-            using namespace std::chrono;
-            replaceHandle(handle_, [this] { return eventLoop().dispatch([this] { timerCallback(); }, 100ms); });
+            replaceSubscription(handle_, [this] { timerCallback(); }, std::chrono::milliseconds{ 100 });
         }
     }
 
@@ -1993,18 +1992,14 @@ public:
 
     void audioDeviceListChanged()
     {
-        replaceHandle(
+        replaceSubscription(
             handle_,
             [this]
             {
-                return eventLoop().dispatch(
-                    [this]
-                    {
-                        scanForDevices();
-                        callDeviceChangeListeners();
-                    },
-                    {});
-            });
+                scanForDevices();
+                callDeviceChangeListeners();
+            },
+            {});
     }
 
     void triggerAsyncAudioDeviceListChange()

--- a/modules/juce_audio_devices/native/juce_win32_ASIO.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_ASIO.cpp
@@ -715,7 +715,8 @@ public:
 
     void resetRequest() noexcept
     {
-        handle_ = eventLoop().dispatch([this] { timerCallback(); }, std::chrono::milliseconds(500));
+        using namespace std::chrono;
+        replaceHandle(handle_, [this] { return eventLoop().dispatch([this] { timerCallback(); }, 500ms); });
     }
 
     void timerCallback() override

--- a/modules/juce_audio_devices/native/juce_win32_ASIO.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_ASIO.cpp
@@ -715,8 +715,7 @@ public:
 
     void resetRequest() noexcept
     {
-        using namespace std::chrono;
-        replaceHandle(handle_, [this] { return eventLoop().dispatch([this] { timerCallback(); }, 500ms); });
+        replaceSubscription(handle_, [this] { timerCallback(); }, std::chrono::milliseconds{ 500 });
     }
 
     void timerCallback() override


### PR DESCRIPTION
`replaceHandle` deletes the current subscription to the rx event loop before opening a new one. I moved it to `YsJuce`(our own code) from `juce_mac_CoreAudio.cpp` and applied it to one instance in the ASIO driver.