### PR TITLE
[YS-17747] Disable unused input channels on Core Audio

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -608,6 +608,14 @@ public:
         return OK (AudioObjectSetPropertyData (deviceID, &pa, 0, 0, sizeof (sr), &sr));
     }
 
+    /**
+     * Yousician patch: disable input channels that are not used. When an audio device is opened, by default CoreAudio
+     * opens all input and output channels. Juce does not change this, but just ignores unused channels. OS X on the
+     * other hand requires microphone permission for audio input, so just starting output through Juce on a full duplex
+     * device would trigger microphone permission dialog. To avoid this, unused channels are disabled before starting
+     * the device. In principle the same could be done to outputs too, but it seems that the extra outputs don't cause
+     * any problems.
+     */
     bool configureInputChannels() const
     {
         UInt32 const channelCount = inChanNames.size();

--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -682,7 +682,7 @@ public:
             {
                 if (OK (AudioDeviceCreateIOProcID (deviceID, audioIOProc, this, &audioProcID)))
                 {
-                    if (OK (AudioDeviceStart (deviceID, audioIOProc)))
+                    if (OK (AudioDeviceStart (deviceID, audioProcID)))
                     {
                         started = true;
                     }
@@ -715,7 +715,7 @@ public:
              && (deviceID != 0)
              && ! leaveInterruptRunning)
         {
-            OK (AudioDeviceStop (deviceID, audioIOProc));
+            OK (AudioDeviceStop (deviceID, audioProcID));
             OK (AudioDeviceDestroyIOProcID (deviceID, audioProcID));
             audioProcID = 0;
 


### PR DESCRIPTION
This enables running duplex devices in output only direction. Without this patch, starting output on a device has input channels always starts input on all channels, and then ignores it. This triggers microphone permission dialog on OS X 10.14 and later. Outputs could be disabled similarly for input only devices, but since the only benefit would be very small reduction in CPU use and possibly allowing another program use the output in exclusive mode, I didn't do it.