### PR TITLE
[YS-20406] Fix device list callback and unplugged event on WASAPI

### DIFF
--- a/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp
@@ -373,7 +373,7 @@ public:
           actualBufferSize (0),
           bytesPerSample (0),
           bytesPerFrame (0),
-          sampleRateHasChanged (false)
+          audioSessionDisconnected (false)
     {
         clientEvent = CreateEvent (nullptr, false, false, nullptr);
 
@@ -448,7 +448,7 @@ public:
         if (client != nullptr
              && tryInitialisingWithBufferSize (bufferSizeSamples))
         {
-            sampleRateHasChanged = false;
+            audioSessionDisconnected = false;
 
             channelMaps.clear();
             for (int i = 0; i <= channels.getHighestBit(); ++i)
@@ -479,9 +479,15 @@ public:
         ResetEvent (clientEvent);
     }
 
-    void deviceSampleRateChanged()
+    void deviceDisconnected(AudioSessionDisconnectReason reason)
     {
-        sampleRateHasChanged = true;
+        audioSessionDisconnected = true;
+        disconnectReason = reason;
+    }
+
+    bool sampleRateHasChanged() const
+    {
+        return audioSessionDisconnected && disconnectReason == DisconnectReasonFormatChanged;
     }
 
     //==============================================================================
@@ -498,7 +504,8 @@ public:
     Array<int> channelMaps;
     UINT32 actualBufferSize;
     int bytesPerSample, bytesPerFrame;
-    bool sampleRateHasChanged;
+    bool audioSessionDisconnected;
+    AudioSessionDisconnectReason disconnectReason;
 
     virtual void updateFormat (bool isFloat) = 0;
 
@@ -518,8 +525,7 @@ private:
 
         JUCE_COMRESULT OnSessionDisconnected (AudioSessionDisconnectReason reason)
         {
-            if (reason == DisconnectReasonFormatChanged)
-                owner.deviceSampleRateChanged();
+            owner.deviceDisconnected(reason);
 
             return S_OK;
         }
@@ -542,7 +548,7 @@ private:
         if (audioSessionControl != nullptr)
         {
             sessionEventCallback = new SessionEventCallback (*this);
-            audioSessionControl->RegisterAudioSessionNotification (sessionEventCallback);
+            HRESULT result = audioSessionControl->RegisterAudioSessionNotification (sessionEventCallback);
             sessionEventCallback->Release(); // (required because ComBaseClassHelper objects are constructed with a ref count of 1)
         }
     }
@@ -1247,7 +1253,7 @@ public:
                 if (outputDevice == nullptr)
                 {
                     if (WaitForSingleObject (inputDevice->clientEvent, 1000) == WAIT_TIMEOUT)
-                        break;
+                        goto checkAudioSessionDisconnect;
 
                     inputDevice->handleDeviceBuffer();
 
@@ -1262,7 +1268,7 @@ public:
 
                 inputDevice->copyBuffersFromReservoir (inputBuffers, numInputBuffers, bufferSize);
 
-                if (inputDevice->sampleRateHasChanged)
+                if (inputDevice->sampleRateHasChanged())
                 {
                     sampleRateHasChanged = true;
                     sampleRateChangedByOutput = false;
@@ -1285,7 +1291,7 @@ public:
                 // the input reservoir is filled up correctly even when bufferSize > device actualBufferSize
                 outputDevice->copyBuffers (const_cast<const float**> (outputBuffers), numOutputBuffers, bufferSize, inputDevice, *this);
 
-                if (outputDevice->sampleRateHasChanged)
+                if (outputDevice->sampleRateHasChanged())
                 {
                     sampleRateHasChanged = true;
                     sampleRateChangedByOutput = true;
@@ -1296,6 +1302,31 @@ public:
             {
                 triggerAsyncUpdate();
                 break; // Quit the thread... will restart it later!
+            }
+            else
+            {
+checkAudioSessionDisconnect:
+                bool disconnected = false;
+                if (inputDevice != nullptr && inputDevice->audioSessionDisconnected)
+                {
+                    const String errorMessage("WASAPI input device disconnected: reason=" + String((int)inputDevice->disconnectReason));
+                    if (callback != nullptr)
+                        callback->audioDeviceError(errorMessage);
+                    disconnected = true;
+                    lastError = errorMessage;
+                }
+                if (outputDevice != nullptr && outputDevice->audioSessionDisconnected)
+                {
+                    const String errorMessage("WASAPI output device disconnected: reason=" + String((int)outputDevice->disconnectReason));
+                    if (callback != nullptr)
+                        callback->audioDeviceError(errorMessage);
+                    disconnected = true;
+                    lastError = errorMessage;
+                }
+                if (disconnected)
+                {
+                    break;
+                }
             }
         }
     }
@@ -1612,6 +1643,8 @@ private:
     //==============================================================================
     void systemDeviceChanged() override
     {
+        auto result = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+
         StringArray newOutNames, newInNames, newOutIds, newInIds;
         scan (newOutNames, newInNames, newOutIds, newInIds);
 
@@ -1628,6 +1661,9 @@ private:
         }
 
         callDeviceChangeListeners();
+
+        if (result == S_OK || result == S_FALSE)
+            CoUninitialize();
     }
 
     //==============================================================================

--- a/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp
@@ -1641,9 +1641,26 @@ private:
     }
 
     //==============================================================================
+    class ComInitializer
+    {
+    public:
+        ComInitializer()
+        : initResult(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED))
+        {}
+
+        ~ComInitializer()
+        {
+            if (initResult == S_OK || initResult == S_FALSE)
+                CoUninitialize();
+        }
+
+    private:
+        HRESULT const initResult;
+    };
+
     void systemDeviceChanged() override
     {
-        auto result = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+        ComInitializer comInit;
 
         StringArray newOutNames, newInNames, newOutIds, newInIds;
         scan (newOutNames, newInNames, newOutIds, newInIds);
@@ -1661,9 +1678,6 @@ private:
         }
 
         callDeviceChangeListeners();
-
-        if (result == S_OK || result == S_FALSE)
-            CoUninitialize();
     }
 
     //==============================================================================

--- a/modules/juce_events/native/juce_win32_HiddenMessageWindow.h
+++ b/modules/juce_events/native/juce_win32_HiddenMessageWindow.h
@@ -115,6 +115,10 @@ private:
     static LRESULT CALLBACK deviceChangeEventCallback (HWND h, const UINT message,
                                                        const WPARAM wParam, const LPARAM lParam)
     {
+        // This duplicates notications from IMMNotificationClient and isn't needed since IMMNotification works
+        // in Vista and newer OS versions and our minimum requirement is 8.1. This class is still present, because
+        // the info from IMMNotificationClient is routed through through triggerAsyncDeviceChangeCallback()
+#if false
         if (message == WM_DEVICECHANGE
              && (wParam == 0x8000 /*DBT_DEVICEARRIVAL*/
                   || wParam == 0x8004 /*DBT_DEVICEREMOVECOMPLETE*/
@@ -123,6 +127,7 @@ private:
             ((DeviceChangeDetector*) GetWindowLongPtr (h, GWLP_USERDATA))
                 ->triggerAsyncDeviceChangeCallback();
         }
+#endif
 
         return DefWindowProc (h, message, wParam, lParam);
     }

--- a/modules/juce_events/native/juce_win32_HiddenMessageWindow.h
+++ b/modules/juce_events/native/juce_win32_HiddenMessageWindow.h
@@ -117,7 +117,7 @@ private:
     {
         // This duplicates notications from IMMNotificationClient and isn't needed since IMMNotification works
         // in Vista and newer OS versions and our minimum requirement is 8.1. This class is still present, because
-        // the info from IMMNotificationClient is routed through through triggerAsyncDeviceChangeCallback()
+        // the info from IMMNotificationClient is routed through triggerAsyncDeviceChangeCallback()
 #if false
         if (message == WM_DEVICECHANGE
              && (wParam == 0x8000 /*DBT_DEVICEARRIVAL*/


### PR DESCRIPTION
This fixes the device list scanning and device unplugged events on WASAPI. Right now we don't do anything except log error with the unplug event, but that might change at same point. JUCE API doesn't have a proper callback for removed device.