### PR TITLE
Cherry-pick fix for GCC bug

### DIFF
--- a/modules/juce_graphics/colour/juce_PixelFormats.h
+++ b/modules/juce_graphics/colour/juce_PixelFormats.h
@@ -104,22 +104,9 @@ public:
 
     //==============================================================================
     forcedinline uint8 getAlpha() const noexcept      { return components.a; }
-    forcedinline uint8 getRed() const noexcept        { return components.r; }
+    forcedinline uint8 getRed()   const noexcept      { return components.r; }
     forcedinline uint8 getGreen() const noexcept      { return components.g; }
-    forcedinline uint8 getBlue() const noexcept       { return components.b; }
-
-   #if JUCE_GCC
-    // NB these are here as a workaround because GCC refuses to bind to packed values.
-    forcedinline uint8& getAlpha() noexcept           { return comps [indexA]; }
-    forcedinline uint8& getRed() noexcept             { return comps [indexR]; }
-    forcedinline uint8& getGreen() noexcept           { return comps [indexG]; }
-    forcedinline uint8& getBlue() noexcept            { return comps [indexB]; }
-   #else
-    forcedinline uint8& getAlpha() noexcept           { return components.a; }
-    forcedinline uint8& getRed() noexcept             { return components.r; }
-    forcedinline uint8& getGreen() noexcept           { return components.g; }
-    forcedinline uint8& getBlue() noexcept            { return components.b; }
-   #endif
+    forcedinline uint8 getBlue()  const noexcept      { return components.b; }
 
     //==============================================================================
     /** Copies another pixel colour over this one.
@@ -339,9 +326,6 @@ private:
     {
         uint32 internal;
         Components components;
-       #if JUCE_GCC
-        uint8 comps[4];  // helper struct needed because gcc does not allow references to packed union members
-       #endif
     };
 }
 #ifndef DOXYGEN
@@ -424,13 +408,9 @@ public:
 
     //==============================================================================
     forcedinline uint8 getAlpha() const noexcept    { return 0xff; }
-    forcedinline uint8 getRed() const noexcept      { return r; }
+    forcedinline uint8 getRed()   const noexcept    { return r; }
     forcedinline uint8 getGreen() const noexcept    { return g; }
-    forcedinline uint8 getBlue() const noexcept     { return b; }
-
-    forcedinline uint8& getRed() noexcept           { return r; }
-    forcedinline uint8& getGreen() noexcept         { return g; }
-    forcedinline uint8& getBlue() noexcept          { return b; }
+    forcedinline uint8 getBlue()  const noexcept    { return b; }
 
     //==============================================================================
     /** Copies another pixel colour over this one.
@@ -645,11 +625,9 @@ public:
 
     //==============================================================================
     forcedinline uint8 getAlpha() const noexcept    { return a; }
-    forcedinline uint8& getAlpha() noexcept         { return a; }
-
-    forcedinline uint8 getRed() const noexcept      { return 0; }
+    forcedinline uint8 getRed()   const noexcept    { return 0; }
     forcedinline uint8 getGreen() const noexcept    { return 0; }
-    forcedinline uint8 getBlue() const noexcept     { return 0; }
+    forcedinline uint8 getBlue()  const noexcept    { return 0; }
 
     //==============================================================================
     /** Copies another pixel colour over this one.

--- a/modules/juce_graphics/native/juce_RenderingHelpers.h
+++ b/modules/juce_graphics/native/juce_RenderingHelpers.h
@@ -579,19 +579,11 @@ namespace EdgeTableFillers
         SolidColour (const Image::BitmapData& image, const PixelARGB colour)
             : destData (image), sourceColour (colour)
         {
-            if (sizeof (PixelType) == 3 && destData.pixelStride == sizeof (PixelType))
-            {
+            if (sizeof (PixelType) == 3 && (size_t) destData.pixelStride == sizeof (PixelType))
                 areRGBComponentsEqual = sourceColour.getRed() == sourceColour.getGreen()
                                             && sourceColour.getGreen() == sourceColour.getBlue();
-                filler[0].set (sourceColour);
-                filler[1].set (sourceColour);
-                filler[2].set (sourceColour);
-                filler[3].set (sourceColour);
-            }
             else
-            {
                 areRGBComponentsEqual = false;
-            }
         }
 
         forcedinline void setEdgeTableYPos (const int y) noexcept
@@ -642,7 +634,6 @@ namespace EdgeTableFillers
         const Image::BitmapData& destData;
         PixelType* linePixels;
         PixelARGB sourceColour;
-        PixelRGB filler [4];
         bool areRGBComponentsEqual;
 
         forcedinline PixelType* getPixel (const int x) const noexcept
@@ -657,47 +648,10 @@ namespace EdgeTableFillers
 
         forcedinline void replaceLine (PixelRGB* dest, const PixelARGB colour, int width) const noexcept
         {
-            if (destData.pixelStride == sizeof (*dest))
-            {
-                if (areRGBComponentsEqual)  // if all the component values are the same, we can cheat..
-                {
-                    memset (dest, colour.getRed(), (size_t) width * 3);
-                }
-                else
-                {
-                    if (width >> 5)
-                    {
-                        const int* const intFiller = reinterpret_cast<const int*> (filler);
-
-                        while (width > 8 && (((pointer_sized_int) dest) & 7) != 0)
-                        {
-                            dest->set (colour);
-                            ++dest;
-                            --width;
-                        }
-
-                        while (width > 4)
-                        {
-                            int* d = reinterpret_cast<int*> (dest);
-                            *d++ = intFiller[0];
-                            *d++ = intFiller[1];
-                            *d++ = intFiller[2];
-                            dest = reinterpret_cast<PixelRGB*> (d);
-                            width -= 4;
-                        }
-                    }
-
-                    while (--width >= 0)
-                    {
-                        dest->set (colour);
-                        ++dest;
-                    }
-                }
-            }
+            if ((size_t) destData.pixelStride == sizeof (*dest) && areRGBComponentsEqual)
+                memset ((void*) dest, colour.getRed(), (size_t) width * 3);   // if all the component values are the same, we can cheat..
             else
-            {
-                JUCE_PERFORM_PIXEL_OP_LOOP (set (colour))
-            }
+                JUCE_PERFORM_PIXEL_OP_LOOP (set (colour));
         }
 
         forcedinline void replaceLine (PixelAlpha* dest, const PixelARGB colour, int width) const noexcept


### PR DESCRIPTION
Cherry picking commit from JUCE repository that fixes a compatibility with GCC 9: 
https://github.com/juce-framework/JUCE/commit/4e0adb2af8b424c43d22bd431011c9a6c57d36b6