### PR TITLE
Handle kAudioObjectPropertyOwnedObjects notification as parameter change

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -937,7 +937,7 @@ private:
 
             case kAudioDevicePropertyDeviceHasChanged:
             case kAudioObjectPropertyOwnedObjects:
-                intern->owner.restart();
+                intern->deviceDetailsChanged();
                 intern->owner.deviceType.triggerAsyncAudioDeviceListChange();
                 break;
 


### PR DESCRIPTION
Looks like Apple stopped notifications about kAudioDevicePropertyNominalSampleRate, kAudioStreamPropertyPhysicalFormat and others when the sample rate and stream format change. kAudioObjectPropertyOwnedObjects seems to still get notifications.