### PR TITLE
Fix WASM build

### DIFF
--- a/modules/juce_core/juce_core.cpp
+++ b/modules/juce_core/juce_core.cpp
@@ -80,6 +80,7 @@
   #include <unistd.h>
   #include <netinet/in.h>
   #include <sys/stat.h>
+  #include <emscripten/emscripten.h>
  #endif
 
  #if JUCE_LINUX || JUCE_BSD
@@ -186,7 +187,10 @@
 #include "zip/juce_ZipFile.cpp"
 #include "files/juce_FileFilter.cpp"
 #include "files/juce_WildcardFileFilter.cpp"
+
+#if ! JUCE_WASM
 #include "native/juce_native_ThreadPriorities.h"
+#endif
 
 //==============================================================================
 #if ! JUCE_WINDOWS


### PR DESCRIPTION
Fix WASM build. The emscripten header is required for compiling `juce_wasm_SystemStats.cpp`. The thread priorities are not used anywhere in a build without `JUCE_EVENTS`.