### PR TITLE
Disable message thread assert on iOS

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreMidi.mm
+++ b/modules/juce_audio_devices/native/juce_mac_CoreMidi.mm
@@ -613,9 +613,14 @@ namespace CoreMidiHelpers
 
     static Array<MidiDeviceInfo> findDevices (bool forInput)
     {
+        // On iOS this may be called from different thread without any apparent problems.
+        // The assertion is disabled to enable running debug builds without disabling this
+        // every time.
+#if !JUCE_IOS
         // It seems that OSX can be a bit picky about the thread that's first used to
         // search for devices. It's safest to use the message thread for calling this.
         JUCE_ASSERT_MESSAGE_THREAD
+#endif
 
         if (getGlobalMidiClient() == 0)
         {


### PR DESCRIPTION
This disables an assert that makes debugging on iOS a bit more difficult.